### PR TITLE
Create example_Initialise_JIT_particles_with_initial_values.py

### DIFF
--- a/Examples/example_Initialise_JIT_particles_with_initial_values.py
+++ b/Examples/example_Initialise_JIT_particles_with_initial_values.py
@@ -19,13 +19,11 @@ def SampleTemp(particle, fieldset, time):
 def SampleInitial(particle, fieldset, time): 
     if particle.sampled == 0:
          particle.temp = fieldset.temp[time, particle.depth, particle.lat, particle.lon]
-         particle.prev_lon = particle.lon
-         particle.prev_lat = particle.lat
          particle.sampled = 1
          
 # Create your kernel list to run,
 # Put the SampleInitial Kernel before the advection kernel to get the initial value of temp before the 1st advection step occurs.
-kernels = SampleInitial + pset.Kernel(AdvectionRK4) +  SampleTemp
+kernels = SampleInitial + pset.Kernel(AdvectionRK4) + SampleTemp
 
 # Excute the code
 pset.execute(kernels, 

--- a/Examples/example_Initialise_JIT_particles_with_initial_values.py
+++ b/Examples/example_Initialise_JIT_particles_with_initial_values.py
@@ -1,0 +1,38 @@
+### This example shows how to create a particle set in JIT mode while still sampling initial conditions of a variable eg. Temperature
+### This works even with mulitple releases during a simulation
+### This is an example of a solution to the github issue here: https://github.com/OceanParcels/parcels/issues/861
+### This code assumes you have already made the fieldset. (This is not a stand-only piece of code)
+
+# First create a particle class which samples values, in this case it is sampling temperature.
+# Within this class create the variable you wish to sample (temp) and initialise it with a value of 0.
+# Also create a variable (sampled) to identify if it is the particles day of release.
+
+class SampleParticle(JITParticle):         # Define a new particle class
+    sampled = Variable('sampled', dtype = np.float32, initial = 0, to_write=False) # variable to identify if it is just released
+    temp = Variable('temp', dtype=np.float32, initial=0)  # initialise temperature
+
+# Create the kernel to sample temperature
+def SampleTemp(particle, fieldset, time):
+    particle.temp = fieldset.temp[time, particle.depth, particle.lat, particle.lon]
+
+# Create the kernel to get the initial temperature value for each particle.
+def SampleInitial(particle, fieldset, time): 
+    if particle.sampled == 0:
+         particle.temp = fieldset.temp[time, particle.depth, particle.lat, particle.lon]
+         particle.prev_lon = particle.lon
+         particle.prev_lat = particle.lat
+         particle.sampled = 1
+         
+# Create your kernel list to run,
+# Put the SampleInitial Kernel before the advection kernel to get the initial value of temp before the 1st advection step occurs.
+kernels = SampleInitial + pset.Kernel(AdvectionRK4) +  SampleTemp
+
+# Excute the code
+pset.execute(kernels, 
+             dt=delta(minutes=30), 
+             output_file=pfile, 
+             verbose_progress=True,
+             #moviedt=delta(hours=1),
+             runtime = runtime,
+             recovery={ErrorCode.ErrorOutOfBounds: DeleteParticle})
+pfile.close()

--- a/Examples/example_Initialise_JIT_particles_with_initial_values.py
+++ b/Examples/example_Initialise_JIT_particles_with_initial_values.py
@@ -16,6 +16,8 @@ def SampleTemp(particle, fieldset, time):
     particle.temp = fieldset.temp[time, particle.depth, particle.lat, particle.lon]
 
 # Create the kernel to get the initial temperature value for each particle.
+# Note at this stage it is calculating the initial values but not recording them in the particle set file
+# This would be useful for calcuating distance travelled etc but not if you want a record of day 0 conditions.
 def SampleInitial(particle, fieldset, time): 
     if particle.sampled == 0:
          particle.temp = fieldset.temp[time, particle.depth, particle.lat, particle.lon]
@@ -24,13 +26,3 @@ def SampleInitial(particle, fieldset, time):
 # Create your kernel list to run,
 # Put the SampleInitial Kernel before the advection kernel to get the initial value of temp before the 1st advection step occurs.
 kernels = SampleInitial + pset.Kernel(AdvectionRK4) + SampleTemp
-
-# Excute the code
-pset.execute(kernels, 
-             dt=delta(minutes=30), 
-             output_file=pfile, 
-             verbose_progress=True,
-             #moviedt=delta(hours=1),
-             runtime = runtime,
-             recovery={ErrorCode.ErrorOutOfBounds: DeleteParticle})
-pfile.close()


### PR DESCRIPTION
This example shows how to create a particle set in JIT mode while still sampling initial conditions of a variable eg. Temperature.  

This is an example of a solution to the github issue here: https://github.com/OceanParcels/parcels/issues/861 and I am attempting to contribute this example as I recently applied it in my own code based upon suggestions in that issue thread.

Note: This is my first attempt at a contribution so please let me know if I am suppose to do anything else for a contribution.

